### PR TITLE
Constify error_desc and perror

### DIFF
--- a/include/private/error.h
+++ b/include/private/error.h
@@ -39,4 +39,4 @@ struct error_code {
     char *const desc;
 };
 
-extern struct error_code *perror;
+extern const struct error_code * const perror;

--- a/kernel/error.c
+++ b/kernel/error.c
@@ -3,7 +3,7 @@
 #include "private/error.h"
 
 /* Ordered by enum value for quick linear search */
-static struct error_code error_desc[] = {
+static const struct error_code error_desc[] = {
     {ERR_OK, "no error"},
     {ERR_FAIL, "generic failure"},
 
@@ -35,4 +35,4 @@ static struct error_code error_desc[] = {
     {ERR_UNKNOWN, "unknown error"},
 };
 
-struct error_code *perror = error_desc;
+const struct error_code * const perror = error_desc;


### PR DESCRIPTION
The error_desc array and the perror pointer are never modified after initialization. Marking them as const moves the data to the read-only section, improving safety.

Before:
$ riscv-none-elf-size ./build/kernel/error.o
   text    data     bss     dec     hex filename
    398     172       0     570     23a ./build/kernel/error.o

After:
$ riscv-none-elf-size ./build/kernel/error.o
   text    data     bss     dec     hex filename
    570       0       0     570     23a ./build/kernel/error.o