### PR TITLE
Fix prototype mismatch of strlen() in libc.h

### DIFF
--- a/include/lib/libc.h
+++ b/include/lib/libc.h
@@ -70,7 +70,7 @@ char *strncat(char *s1, const char *s2, int32_t n);
 int32_t strcmp(const char *s1, const char *s2);
 int32_t strncmp(const char *s1, const char *s2, int32_t n);
 char *strstr(const char *s1, const char *s2);
-int32_t strlen(const char *s1);
+size_t strlen(const char *s1);
 char *strchr(const char *s1, int32_t c);
 char *strpbrk(const char *s1, const char *s2);
 char *strsep(char **pp, const char *delim);


### PR DESCRIPTION
Commit f95a700 ("Correct return type of strlen function") changed the return type of strlen() from int32_t to size_t in its definition, but did not update the prototype in include/lib/libc.h accordingly. This causes a build failure due to a conflicting type declaration:

```
  CC    build/lib/libc.o
lib/libc.c:23:8: error: conflicting types for 'strlen'; have 'size_t(const char *)' {aka 'unsigned int(const char *)'}
   23 | size_t strlen(const char *s)
      |        ^~~~~~
In file included from lib/libc.c:1:
./include/lib/libc.h:73:9: note: previous declaration of 'strlen' with type 'int32_t(const char *)' {aka 'int(const char *)'}
   73 | int32_t strlen(const char *s1);
      |         ^~~~~~
make: *** [Makefile:53: build/lib/libc.o] Error 1
```

Update the strlen() prototype in the header file to match the new return type and fix the build error.

Fixes: f95a700 ("Correct return type of strlen function")