### PR TITLE
Support SMP scheduling and synchronization

### DIFF
--- a/arch/riscv/boot.c
+++ b/arch/riscv/boot.c
@@ -70,10 +70,6 @@ __attribute__((naked, section(".text.prologue"))) void _entry(void)
         "csrw   mideleg, zero\n" /* No interrupt delegation to S-mode */
         "csrw   medeleg, zero\n" /* No exception delegation to S-mode */
 
-        /* Park secondary harts (cores). */
-        "csrr   t0, mhartid\n"
-        "bnez   t0, .Lpark_hart\n"
-
         /* Set the machine trap vector (mtvec) to point to our ISR. */
         "la     t0, _isr\n"
         "csrw   mtvec, t0\n"
@@ -87,14 +83,11 @@ __attribute__((naked, section(".text.prologue"))) void _entry(void)
         "csrw   mie, t0\n"
 
         /* Jump to the C-level main function. */
+        "csrr   a0, mhartid\n"
         "call   main\n"
 
         /* If main() ever returns, it is a fatal error. */
         "call   hal_panic\n"
-
-        ".Lpark_hart:\n"
-        "wfi\n"
-        "j      .Lpark_hart\n"
 
         : /* no outputs */
         : "i"(MSTATUS_MPP_MACH), "i"(MIE_MEIE), "i"(STACK_SIZE_PER_HART)

--- a/arch/riscv/build.mk
+++ b/arch/riscv/build.mk
@@ -16,10 +16,10 @@ DEFINES := -DF_CPU=$(F_CLK) \
            -DUSART_BAUD=$(SERIAL_BAUDRATE) \
            -DF_TIMER=$(F_TICK)
 
-ASFLAGS = -march=rv32imzicsr -mabi=ilp32
+ASFLAGS = -march=rv32imzaicsr -mabi=ilp32
 CFLAGS += -Wall -Wextra -Wshadow -Wno-unused-parameter -Werror
 CFLAGS += -O2 -std=gnu99
-CFLAGS += -march=rv32imzicsr -mabi=ilp32
+CFLAGS += -march=rv32imazicsr -mabi=ilp32
 CFLAGS += -mstrict-align -ffreestanding -nostdlib -fomit-frame-pointer
 CFLAGS += $(INC_DIRS) $(DEFINES) -fdata-sections -ffunction-sections
 ARFLAGS = r

--- a/arch/riscv/build.mk
+++ b/arch/riscv/build.mk
@@ -48,4 +48,4 @@ $(BUILD_KERNEL_DIR)/%.o: $(ARCH_DIR)/%.c | $(BUILD_DIR)
 
 run:
 	@$(call notice, Ready to launch Linmo kernel + application.)
-	$(Q)qemu-system-riscv32 -machine virt -nographic -bios none -kernel $(BUILD_DIR)/image.elf -nographic
+	$(Q)qemu-system-riscv32 -smp 4 -machine virt -nographic -bios none -kernel $(BUILD_DIR)/image.elf -nographic

--- a/arch/riscv/hal.c
+++ b/arch/riscv/hal.c
@@ -325,7 +325,7 @@ void hal_timer_disable(void)
  */
 void hal_interrupt_tick(void)
 {
-    tcb_t *task = kcb->task_current->data;
+    tcb_t *task = get_task_current(kcb)->data;
     if (unlikely(!task))
         hal_panic(); /* Fatal error - invalid task state */
 

--- a/arch/riscv/hal.c
+++ b/arch/riscv/hal.c
@@ -131,11 +131,14 @@ static inline uint64_t mtime_r(void)
 /* Safely read the 64-bit 'mtimecmp' register. */
 static inline uint64_t mtimecmp_r(void)
 {
-    uint32_t hi, lo;
+    uint32_t hi, lo, hartid;
+
+    hartid = read_csr(mhartid);
+
     do {
-        hi = MTIMECMP_H;
-        lo = MTIMECMP_L;
-    } while (hi != MTIMECMP_H);
+        hi = * (volatile uint32_t *) (CLINT_BASE + 0x4004u + 8 * hartid);
+        lo = * (volatile uint32_t *) (CLINT_BASE + 0x4000u + 8 * hartid);
+    } while (hi != *(volatile uint32_t *) (CLINT_BASE + 0x4004u + 8 * hartid));
     return CT64(hi, lo);
 }
 
@@ -152,10 +155,11 @@ static inline void mtimecmp_w(uint64_t val)
     /* Disable interrupts during the critical section to ensure atomicity */
     uint32_t old_mie = read_csr(mie);
     write_csr(mie, old_mie & ~MIE_MTIE);
+    uint32_t hartid = read_csr(mhartid);
 
-    MTIMECMP_L = 0xFFFFFFFF; /* Set to maximum to prevent spurious interrupt */
-    MTIMECMP_H = (uint32_t) (val >> 32); /* Set high word */
-    MTIMECMP_L = (uint32_t) val;         /* Set low word to final value */
+    * (volatile uint32_t *) (CLINT_BASE + 0x4000u + 8 * hartid) = 0xFFFFFFFF; /* Set to maximum to prevent spurious interrupt */
+    * (volatile uint32_t *) (CLINT_BASE + 0x4004u + 8 * hartid) = (uint32_t) (val >> 32); /* Set high word */
+    * (volatile uint32_t *) (CLINT_BASE + 0x4000u + 8 * hartid) = (uint32_t) val;         /* Set low word to final value */
 
     /* Re-enable timer interrupts if they were previously enabled */
     write_csr(mie, old_mie);

--- a/arch/riscv/spinlock.h
+++ b/arch/riscv/spinlock.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <hal.h>
+
+/* Spinlock structure */
+typedef struct {
+    volatile uint32_t lock;
+} spinlock_t;
+
+#define SPINLOCK_INITIALIZER { 0 }
+
+/* Save and restore interrupt state */
+static inline uint32_t intr_save(void)
+{
+    uint32_t mstatus_val = read_csr(mstatus);
+    _di();
+    return mstatus_val;
+}
+
+static inline void intr_restore(uint32_t mstatus_val)
+{
+    write_csr(mstatus, mstatus_val);
+}
+
+/* CPU relax */
+static inline void cpu_relax(void)
+{
+    asm volatile("nop");
+}
+
+/* Basic spinlock API */
+static inline void spin_lock(spinlock_t *lock)
+{
+    while (__sync_lock_test_and_set(&lock->lock, 1)) {
+        while (lock->lock)
+            cpu_relax();
+    }
+}
+
+static inline void spin_unlock(spinlock_t *lock)
+{
+    __sync_lock_release(&lock->lock);
+}
+
+static inline int spin_trylock(spinlock_t *lock)
+{
+    return (__sync_lock_test_and_set(&lock->lock, 1) == 0);
+}
+
+/* IRQ-safe spinlock (no state saving) */
+static inline void spin_lock_irq(spinlock_t *lock)
+{
+    _di();
+    spin_lock(lock);
+}
+
+static inline void spin_unlock_irq(spinlock_t *lock)
+{
+    spin_unlock(lock);
+    _ei();
+}
+
+/* IRQ-safe spinlock (with state saving) */
+static inline void spin_lock_irqsave(spinlock_t *lock, uint32_t *flags)
+{
+    *flags = intr_save();
+    spin_lock(lock);
+}
+
+static inline void spin_unlock_irqrestore(spinlock_t *lock, uint32_t flags)
+{
+    spin_unlock(lock);
+    intr_restore(flags);
+}

--- a/include/sys/task.h
+++ b/include/sys/task.h
@@ -108,39 +108,6 @@ extern kcb_t *kcb;
 /* Task lookup cache size for frequently accessed tasks */
 #define TASK_CACHE_SIZE 4
 
-/* Disables/enables ALL maskable interrupts globally.
- * This provides the strongest protection against concurrency from both other
- * tasks and all ISRs. Use this when modifying data shared with any ISR.
- * WARNING: This increases interrupt latency. Use NOSCHED macros if protection
- * is only needed against task preemption.
- */
-#define CRITICAL_ENTER()     \
-    do {                     \
-        if (kcb->preemptive) \
-            _di();           \
-    } while (0)
-#define CRITICAL_LEAVE()     \
-    do {                     \
-        if (kcb->preemptive) \
-            _ei();           \
-    } while (0)
-
-/* Disables/enables ONLY the scheduler timer interrupt.
- * This is a lighter-weight critical section that prevents task preemption but
- * allows other hardware interrupts (e.g., UART) to be serviced, minimizing
- * latency. Use this when protecting data shared between tasks.
- */
-#define NOSCHED_ENTER()          \
-    do {                         \
-        if (kcb->preemptive)     \
-            hal_timer_disable(); \
-    } while (0)
-#define NOSCHED_LEAVE()         \
-    do {                        \
-        if (kcb->preemptive)    \
-            hal_timer_enable(); \
-    } while (0)
-
 /* Core Kernel and Task Management API */
 
 /* Prints a fatal error message and halts the system. */

--- a/include/sys/task.h
+++ b/include/sys/task.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hal.h>
+#include <spinlock.h>
 #include <lib/list.h>
 #include <lib/queue.h>
 
@@ -87,6 +88,8 @@ typedef struct {
     list_t *timer_list; /* List of active software timers. */
     /* Global system tick counter, incremented by the timer ISR. */
     volatile uint32_t ticks;
+
+    spinlock_t kcb_lock;
 } kcb_t;
 
 /* Global pointer to the singleton Kernel Control Block. */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -56,10 +56,10 @@ int32_t main(int32_t hartid)
     mo_task_spawn(idle_task, DEFAULT_STACK_SIZE);
 
     /* Verify that the application created at least one task.
-     * If 'kcb->task_current' is still NULL, it means mo_task_spawn was never
+     * If 'get_task_current()' is still NULL, it means mo_task_spawn was never
      * successfully called.
      */
-    if (!kcb->task_current)
+    if (!get_task_current())
         panic(ERR_NO_TASKS);
 
     /* Save the kernel's context. This is a formality to establish a base
@@ -70,10 +70,11 @@ int32_t main(int32_t hartid)
     spin_lock(&finish_lock);
 
     /* Launch the first task.
-     * 'kcb->task_current' was set by the first call to mo_task_spawn.
+     * 'get_task_current()' was set by the first call to mo_task_spawn.
      * This function transfers control and does not return.
      */
-    tcb_t *first_task = kcb->task_current->data;
+
+    tcb_t *first_task = get_task_current()->data;
     if (!first_task)
         panic(ERR_NO_TASKS);
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -5,6 +5,12 @@
 
 #include "private/error.h"
 
+static void idle_task(void)
+{
+    while (1)
+        mo_task_wfi();
+}
+
 static volatile bool finish = false;
 static spinlock_t finish_lock = SPINLOCK_INITIALIZER;
 
@@ -46,6 +52,8 @@ int32_t main(int32_t hartid)
         spin_unlock(&finish_lock);
     }
     spin_unlock(&finish_lock);
+
+    mo_task_spawn(idle_task, DEFAULT_STACK_SIZE);
 
     /* Verify that the application created at least one task.
      * If 'kcb->task_current' is still NULL, it means mo_task_spawn was never

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -47,10 +47,10 @@ static list_node_t *find_node_by_data(list_t *list, void *data)
  */
 static void mutex_block_atomic(list_t *waiters)
 {
-    if (!waiters || !kcb || !kcb->task_current || !kcb->task_current->data)
+    if (!waiters || !kcb || !get_task_current() || !get_task_current()->data)
         panic(ERR_SEM_OPERATION);
 
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
 
     /* Add to waiters list */
     if (!list_pushback(waiters, self))
@@ -198,7 +198,7 @@ int32_t mo_mutex_timedlock(mutex_t *m, uint32_t ticks)
     }
 
     /* Must block with timeout */
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
     if (!list_pushback(m->waiters, self)) {
         spin_unlock_irqrestore(&mutex_lock, mutex_flags);
         panic(ERR_SEM_OPERATION);
@@ -353,7 +353,7 @@ int32_t mo_cond_wait(cond_t *c, mutex_t *m)
 
     /* Atomically add to wait list and block */
     spin_lock_irqsave(&mutex_lock, &mutex_flags);
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
     if (!list_pushback(c->waiters, self)) {
         spin_unlock_irqrestore(&mutex_lock, mutex_flags);
         panic(ERR_SEM_OPERATION);
@@ -399,7 +399,7 @@ int32_t mo_cond_timedwait(cond_t *c, mutex_t *m, uint32_t ticks)
 
     /* Atomically add to wait list */
     spin_lock_irqsave(&mutex_lock, &mutex_flags);
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
     if (!list_pushback(c->waiters, self)) {
         spin_unlock_irqrestore(&mutex_lock, mutex_flags);
         panic(ERR_SEM_OPERATION);

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -289,7 +289,11 @@ static int32_t noop_rtsched(void)
 /* The main entry point from the system tick interrupt. */
 void dispatcher(void)
 {
+    uint32_t flag = 0;
+
+    spin_lock_irqsave(&kcb->kcb_lock, &flag);
     kcb->ticks++;
+    spin_unlock_irqrestore(&kcb->kcb_lock, flag);
     _timer_tick_handler();
     _dispatch();
 }

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -6,6 +6,7 @@
  */
 
 #include <hal.h>
+#include <spinlock.h>
 #include <lib/queue.h>
 #include <sys/task.h>
 
@@ -46,6 +47,9 @@ static struct {
     tcb_t *task;
 } task_cache[TASK_CACHE_SIZE];
 static uint8_t cache_index = 0;
+
+static spinlock_t task_lock = SPINLOCK_INITIALIZER;
+static uint32_t task_flags = 0;
 
 static inline bool is_valid_task(tcb_t *task)
 {
@@ -383,12 +387,12 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
     }
 
     /* Minimize critical section duration */
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
 
     if (!kcb->tasks) {
         kcb->tasks = list_create();
         if (!kcb->tasks) {
-            CRITICAL_LEAVE();
+            spin_unlock_irqrestore(&task_lock, task_flags);
             free(tcb->stack);
             free(tcb);
             panic(ERR_KCB_ALLOC);
@@ -397,7 +401,7 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
 
     list_node_t *node = list_pushback(kcb->tasks, tcb);
     if (!node) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         free(tcb->stack);
         free(tcb);
         panic(ERR_TCB_ALLOC);
@@ -410,7 +414,7 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
     if (!kcb->task_current)
         kcb->task_current = node;
 
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
 
     /* Initialize execution context outside critical section */
     hal_context_init(&tcb->context, (size_t) tcb->stack, new_stack_size,
@@ -430,16 +434,16 @@ int32_t mo_task_cancel(uint16_t id)
     if (id == 0 || id == mo_task_id())
         return ERR_TASK_CANT_REMOVE;
 
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *tcb = node->data;
     if (!tcb || tcb->state == TASK_RUNNING) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_CANT_REMOVE;
     }
 
@@ -459,7 +463,7 @@ int32_t mo_task_cancel(uint16_t id)
     if (kcb->last_ready_hint == node)
         kcb->last_ready_hint = NULL;
 
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
 
     /* Free memory outside critical section */
     free(tcb->stack);
@@ -478,16 +482,16 @@ void mo_task_delay(uint16_t ticks)
     if (!ticks)
         return;
 
-    NOSCHED_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data)) {
-        NOSCHED_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return;
     }
 
     tcb_t *self = kcb->task_current->data;
     self->delay = ticks;
     self->state = TASK_BLOCKED;
-    NOSCHED_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
 
     mo_task_yield();
 }
@@ -497,17 +501,17 @@ int32_t mo_task_suspend(uint16_t id)
     if (id == 0)
         return ERR_TASK_NOT_FOUND;
 
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task || (task->state != TASK_READY && task->state != TASK_RUNNING &&
                   task->state != TASK_BLOCKED)) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_CANT_SUSPEND;
     }
 
@@ -518,7 +522,7 @@ int32_t mo_task_suspend(uint16_t id)
     if (kcb->last_ready_hint == node)
         kcb->last_ready_hint = NULL;
 
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
 
     if (is_current)
         mo_task_yield();
@@ -531,21 +535,21 @@ int32_t mo_task_resume(uint16_t id)
     if (id == 0)
         return ERR_TASK_NOT_FOUND;
 
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task || task->state != TASK_SUSPENDED) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_CANT_RESUME;
     }
 
     task->state = TASK_READY;
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
     return ERR_OK;
 }
 
@@ -554,22 +558,22 @@ int32_t mo_task_priority(uint16_t id, uint16_t priority)
     if (id == 0 || !is_valid_priority(priority))
         return ERR_TASK_INVALID_PRIO;
 
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     uint8_t base = (uint8_t) (priority >> 8);
     task->prio = ((uint16_t) base << 8) | base;
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
 
     return ERR_OK;
 }
@@ -579,21 +583,21 @@ int32_t mo_task_rt_priority(uint16_t id, void *priority)
     if (id == 0)
         return ERR_TASK_NOT_FOUND;
 
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task) {
-        CRITICAL_LEAVE();
+        spin_unlock_irqrestore(&task_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     task->rt_prio = priority;
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
     return ERR_OK;
 }
 
@@ -609,9 +613,9 @@ int32_t mo_task_idref(void *task_entry)
     if (!task_entry || !kcb->tasks)
         return ERR_TASK_NOT_FOUND;
 
-    CRITICAL_ENTER();
+    spin_lock_irqsave(&task_lock, &task_flags);
     list_node_t *node = list_foreach(kcb->tasks, refcmp, task_entry);
-    CRITICAL_LEAVE();
+    spin_unlock_irqrestore(&task_lock, task_flags);
 
     return node ? ((tcb_t *) node->data)->id : ERR_TASK_NOT_FOUND;
 }

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -23,7 +23,7 @@ void _timer_tick_handler(void);
  */
 static kcb_t kernel_state = {
     .tasks = NULL,
-    .task_current = NULL,
+    .task_current = {},
     .rt_sched = noop_rtsched,
     .timer_list = NULL, /* Managed by timer.c, but stored here. */
     .next_tid = 1,      /* Start from 1 to avoid confusion with invalid ID 0 */
@@ -85,10 +85,10 @@ static void task_stack_check(void)
     if (!should_check)
         return;
 
-    if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data))
+    if (unlikely(!kcb || !get_task_current() || !get_task_current()->data))
         panic(ERR_STACK_CHECK);
 
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
     if (unlikely(!is_valid_task(self)))
         panic(ERR_STACK_CHECK);
 
@@ -205,7 +205,7 @@ void _yield(void) __attribute__((weak, alias("yield")));
 /* Scheduler with hint-based ready task search */
 static list_node_t *find_next_ready_task(void)
 {
-    if (unlikely(!kcb->task_current))
+    if (unlikely(!get_task_current()))
         return NULL;
 
     list_node_t *node;
@@ -225,7 +225,7 @@ static list_node_t *find_next_ready_task(void)
         }
     }
 
-    node = kcb->task_current;
+    node = get_task_current();
     while (itcnt++ < SCHED_IMAX) {
         node = list_cnext(kcb->tasks, node);
         if (unlikely(!node || !node->data))
@@ -258,11 +258,11 @@ static list_node_t *find_next_ready_task(void)
 /* Scheduler with reduced overhead */
 static uint16_t schedule_next_task(void)
 {
-    if (unlikely(!kcb->task_current || !kcb->task_current->data))
+    if (unlikely(!get_task_current() || !get_task_current()->data))
         panic(ERR_NO_TASKS);
 
     /* Mark the previously running task as ready for the next cycle. */
-    tcb_t *current_task = kcb->task_current->data;
+    tcb_t *current_task = get_task_current()->data;
     if (current_task->state == TASK_RUNNING)
         current_task->state = TASK_READY;
 
@@ -273,7 +273,7 @@ static uint16_t schedule_next_task(void)
     }
 
     /* Update scheduler state */
-    kcb->task_current = next_node;
+    set_task_current(next_node);
     tcb_t *next_task = next_node->data;
     next_task->state = TASK_RUNNING;
 
@@ -297,11 +297,11 @@ void dispatcher(void)
 /* Top-level context-switch for preemptive scheduling. */
 void dispatch(void)
 {
-    if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data))
+    if (unlikely(!kcb || !get_task_current() || !get_task_current()->data))
         panic(ERR_NO_TASKS);
 
     /* Return from longjmp: context is restored, continue task execution. */
-    if (setjmp(((tcb_t *) kcb->task_current->data)->context) != 0)
+    if (setjmp(((tcb_t *) get_task_current()->data)->context) != 0)
         return;
 
     task_stack_check();
@@ -313,16 +313,16 @@ void dispatch(void)
     }
 
     hal_interrupt_tick();
-    longjmp(((tcb_t *) kcb->task_current->data)->context, 1);
+    longjmp(((tcb_t *) get_task_current()->data)->context, 1);
 }
 
 /* Cooperative context switch */
 void yield(void)
 {
-    if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data))
+    if (unlikely(!kcb || !get_task_current() || !get_task_current()->data))
         return;
 
-    if (setjmp(((tcb_t *) kcb->task_current->data)->context) != 0)
+    if (setjmp(((tcb_t *) get_task_current()->data)->context) != 0)
         return;
 
     task_stack_check();
@@ -332,7 +332,7 @@ void yield(void)
         list_foreach(kcb->tasks, delay_update, NULL);
 
     schedule_next_task();
-    longjmp(((tcb_t *) kcb->task_current->data)->context, 1);
+    longjmp(((tcb_t *) get_task_current()->data)->context, 1);
 }
 
 /* Stack initialization with minimal overhead */
@@ -411,8 +411,8 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
     tcb->id = kcb->next_tid++;
     kcb->task_count++;
 
-    if (!kcb->task_current)
-        kcb->task_current = node;
+    if (!get_task_current())
+        set_task_current(node);
 
     spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
@@ -483,12 +483,12 @@ void mo_task_delay(uint16_t ticks)
         return;
 
     spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
-    if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data)) {
+    if (unlikely(!kcb || !get_task_current() || !get_task_current()->data)) {
         spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return;
     }
 
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
     self->delay = ticks;
     self->state = TASK_BLOCKED;
     spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
@@ -516,7 +516,7 @@ int32_t mo_task_suspend(uint16_t id)
     }
 
     task->state = TASK_SUSPENDED;
-    bool is_current = (kcb->task_current == node);
+    bool is_current = (get_task_current() == node);
 
     /* Clear ready hint if suspending that task */
     if (kcb->last_ready_hint == node)
@@ -603,9 +603,9 @@ int32_t mo_task_rt_priority(uint16_t id, void *priority)
 
 uint16_t mo_task_id(void)
 {
-    if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data))
+    if (unlikely(!kcb || !get_task_current() || !get_task_current()->data))
         return 0;
-    return ((tcb_t *) kcb->task_current->data)->id;
+    return ((tcb_t *) get_task_current()->data)->id;
 }
 
 int32_t mo_task_idref(void *task_entry)
@@ -647,11 +647,11 @@ uint64_t mo_uptime(void)
 
 void _sched_block(queue_t *wait_q)
 {
-    if (unlikely(!wait_q || !kcb || !kcb->task_current ||
-                 !kcb->task_current->data))
+    if (unlikely(!wait_q || !kcb || !get_task_current() ||
+                 !get_task_current()->data))
         panic(ERR_SEM_OPERATION);
 
-    tcb_t *self = kcb->task_current->data;
+    tcb_t *self = get_task_current()->data;
 
     if (queue_enqueue(wait_q, self) != 0) {
         panic(ERR_SEM_OPERATION);

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -31,6 +31,7 @@ static kcb_t kernel_state = {
     .ticks = 0,
     .preemptive = true, /* Default to preemptive mode */
     .last_ready_hint = NULL,
+    .kcb_lock = SPINLOCK_INITIALIZER,
 };
 kcb_t *kcb = &kernel_state;
 
@@ -48,7 +49,6 @@ static struct {
 } task_cache[TASK_CACHE_SIZE];
 static uint8_t cache_index = 0;
 
-static spinlock_t task_lock = SPINLOCK_INITIALIZER;
 static uint32_t task_flags = 0;
 
 static inline bool is_valid_task(tcb_t *task)
@@ -387,12 +387,12 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
     }
 
     /* Minimize critical section duration */
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
 
     if (!kcb->tasks) {
         kcb->tasks = list_create();
         if (!kcb->tasks) {
-            spin_unlock_irqrestore(&task_lock, task_flags);
+            spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
             free(tcb->stack);
             free(tcb);
             panic(ERR_KCB_ALLOC);
@@ -401,7 +401,7 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
 
     list_node_t *node = list_pushback(kcb->tasks, tcb);
     if (!node) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         free(tcb->stack);
         free(tcb);
         panic(ERR_TCB_ALLOC);
@@ -414,7 +414,7 @@ int32_t mo_task_spawn(void *task_entry, uint16_t stack_size_req)
     if (!kcb->task_current)
         kcb->task_current = node;
 
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
     /* Initialize execution context outside critical section */
     hal_context_init(&tcb->context, (size_t) tcb->stack, new_stack_size,
@@ -434,16 +434,16 @@ int32_t mo_task_cancel(uint16_t id)
     if (id == 0 || id == mo_task_id())
         return ERR_TASK_CANT_REMOVE;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *tcb = node->data;
     if (!tcb || tcb->state == TASK_RUNNING) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_CANT_REMOVE;
     }
 
@@ -463,7 +463,7 @@ int32_t mo_task_cancel(uint16_t id)
     if (kcb->last_ready_hint == node)
         kcb->last_ready_hint = NULL;
 
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
     /* Free memory outside critical section */
     free(tcb->stack);
@@ -482,16 +482,16 @@ void mo_task_delay(uint16_t ticks)
     if (!ticks)
         return;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     if (unlikely(!kcb || !kcb->task_current || !kcb->task_current->data)) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return;
     }
 
     tcb_t *self = kcb->task_current->data;
     self->delay = ticks;
     self->state = TASK_BLOCKED;
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
     mo_task_yield();
 }
@@ -501,17 +501,17 @@ int32_t mo_task_suspend(uint16_t id)
     if (id == 0)
         return ERR_TASK_NOT_FOUND;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task || (task->state != TASK_READY && task->state != TASK_RUNNING &&
                   task->state != TASK_BLOCKED)) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_CANT_SUSPEND;
     }
 
@@ -522,7 +522,7 @@ int32_t mo_task_suspend(uint16_t id)
     if (kcb->last_ready_hint == node)
         kcb->last_ready_hint = NULL;
 
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
     if (is_current)
         mo_task_yield();
@@ -535,21 +535,21 @@ int32_t mo_task_resume(uint16_t id)
     if (id == 0)
         return ERR_TASK_NOT_FOUND;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task || task->state != TASK_SUSPENDED) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_CANT_RESUME;
     }
 
     task->state = TASK_READY;
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
     return ERR_OK;
 }
 
@@ -558,22 +558,22 @@ int32_t mo_task_priority(uint16_t id, uint16_t priority)
     if (id == 0 || !is_valid_priority(priority))
         return ERR_TASK_INVALID_PRIO;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     uint8_t base = (uint8_t) (priority >> 8);
     task->prio = ((uint16_t) base << 8) | base;
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
     return ERR_OK;
 }
@@ -583,21 +583,21 @@ int32_t mo_task_rt_priority(uint16_t id, void *priority)
     if (id == 0)
         return ERR_TASK_NOT_FOUND;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     list_node_t *node = find_task_node_by_id(id);
     if (!node) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     tcb_t *task = node->data;
     if (!task) {
-        spin_unlock_irqrestore(&task_lock, task_flags);
+        spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
         return ERR_TASK_NOT_FOUND;
     }
 
     task->rt_prio = priority;
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
     return ERR_OK;
 }
 
@@ -613,9 +613,9 @@ int32_t mo_task_idref(void *task_entry)
     if (!task_entry || !kcb->tasks)
         return ERR_TASK_NOT_FOUND;
 
-    spin_lock_irqsave(&task_lock, &task_flags);
+    spin_lock_irqsave(&kcb->kcb_lock, &task_flags);
     list_node_t *node = list_foreach(kcb->tasks, refcmp, task_entry);
-    spin_unlock_irqrestore(&task_lock, task_flags);
+    spin_unlock_irqrestore(&kcb->kcb_lock, task_flags);
 
     return node ? ((tcb_t *) node->data)->id : ERR_TASK_NOT_FOUND;
 }

--- a/lib/libc.c
+++ b/lib/libc.c
@@ -1,5 +1,6 @@
 #include <lib/libc.h>
 #include <stdarg.h>
+#include <spinlock.h>
 
 #include "private/stdio.h"
 #include "private/utils.h"
@@ -896,15 +897,20 @@ static int vsprintf(char **buf, const char *fmt, va_list args)
     return len;
 }
 
+
+static spinlock_t printf_lock = SPINLOCK_INITIALIZER;
+static uint32_t printf_flags = 0;
 /* Formatted output to stdout. */
 int32_t printf(const char *fmt, ...)
 {
     va_list args;
     int32_t v;
 
+    spin_lock_irqsave(&printf_lock, &printf_flags);
     va_start(args, fmt);
     v = vsprintf(0, fmt, args);
     va_end(args);
+    spin_unlock_irqrestore(&printf_lock, printf_flags);
     return v;
 }
 


### PR DESCRIPTION
Enable SMP support by adding multi-core QEMU simulation and adapting
RISC-V boot for per-hart stacks and timers. It replaces interrupt
masking with spinlocks in core kernel subsystems for safe concurrency,
updates the kernel control block to track per-hart current tasks, and
spawns idle tasks at boot to prevent panics. Spinlock-based
synchronization replaces hart parking during boot, and printf output is
protected against interleaving. A spinlock implementation using RV32A
atomics is also included. These changes enable stable multi-core
operation.