### PR TITLE
Fix reversed output and optimize base-10 conversion

### DIFF
--- a/lib/libc.c
+++ b/lib/libc.c
@@ -495,7 +495,7 @@ static char *__str_base10(uint32_t value, char *buffer, int *length)
     /* Reverse digits into output buffer */
     *length = pos;
     for (int i = 0; i < pos; i++) {
-        buffer[i] = tmp[pos - 1 - i];
+        buffer[i] = tmp[i];
     }
 
     return buffer;
@@ -573,6 +573,14 @@ void itoa(int32_t i, char *s, int32_t base)
         }
     } else if (base == 10) { /* Decimal conversion */
         __str_base10_signed(i, s, &len);
+
+        /* Reverse the string. */
+        q = s + len;
+        for (*q = 0; p <= --q; p++) {
+            c = *p;
+            *p = *q;
+            *q = c;
+        }
     } else { /* Other bases */
         if (i >= 0) {
             do {

--- a/lib/libc.c
+++ b/lib/libc.c
@@ -470,9 +470,6 @@ static char *__str_base10(uint32_t value, char *buffer, int *length)
         *length = 1;
         return buffer;
     }
-
-    /* Max digits for 32-bit: 4,294,967,295 (10 digits) + sign + null */
-    char tmp[12];
     int pos = 0;
 
     while (value > 0) {
@@ -488,15 +485,10 @@ static char *__str_base10(uint32_t value, char *buffer, int *length)
         q += t;
         r -= (((t << 2) + t) << 1);
 
-        tmp[pos++] = '0' + r;
+        buffer[pos++] = '0' + r;
         value = q;
     }
-
-    /* Reverse digits into output buffer */
     *length = pos;
-    for (int i = 0; i < pos; i++) {
-        buffer[i] = tmp[i];
-    }
 
     return buffer;
 }


### PR DESCRIPTION
Fix incorrect decimal output and improves the efficiency of base-10
conversion routines used by itoa() and vsprintf(). The bug was caused
by an unnecessary reversal of digits in __str_base10(), resulting in
reversed output. This is corrected by writing digits in the correct
order and applying a single final reversal in itoa() for signed
numbers. Additionally, the implementation is simplified by removing the
temporary buffer in __str_base10() and writing digits directly into the
output buffer, reducing memory operations and improving performance.