### PR TITLE
Merge if-statements in queue_destroy()

### DIFF
--- a/lib/queue.c
+++ b/lib/queue.c
@@ -36,11 +36,8 @@ queue_t *queue_create(int32_t capacity)
  */
 int32_t queue_destroy(queue_t *q)
 {
-    if (!q)
-        return ERR_FAIL;
-
     /* Refuse to destroy a non-empty queue. */
-    if (!queue_is_empty(q))
+    if (!q || !queue_is_empty(q))
         return ERR_FAIL;
 
     free(q->buf);


### PR DESCRIPTION
This change merges redundant conditional checks in `queue_destroy()`.
It avoids one `li` and one `j` instruction associated with return `ERR_FAIL`.