### PR TITLE
Move abs function from memory.c to new math.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ KERNEL_OBJS := timer.o mqueue.o pipe.o semaphore.o mutex.o error.o syscall.o tas
 KERNEL_OBJS := $(addprefix $(BUILD_KERNEL_DIR)/,$(KERNEL_OBJS))
 deps += $(KERNEL_OBJS:%.o=%.o.d)
 
-LIB_OBJS := ctype.o malloc.o memory.o random.o stdio.o string.o queue.o
+LIB_OBJS := ctype.o malloc.o math.o memory.o random.o stdio.o string.o queue.o
 LIB_OBJS := $(addprefix $(BUILD_LIB_DIR)/,$(LIB_OBJS))
 deps += $(LIB_OBJS:%.o=%.o.d)
 

--- a/lib/math.c
+++ b/lib/math.c
@@ -1,0 +1,9 @@
+/* libc: Math function. */
+
+#include <lib/libc.h>
+
+/* Returns the absolute value of an integer. */
+int32_t abs(int32_t n)
+{
+    return n >= 0 ? n : -n;
+}

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -122,9 +122,3 @@ int32_t memcmp(const void *cs, const void *ct, uint32_t n)
      */
     return (n == 0) ? 0 : ((*r1 < *r2) ? -1 : 1);
 }
-
-/* Returns the absolute value of an integer. */
-int32_t abs(int32_t n)
-{
-    return n >= 0 ? n : -n;
-}


### PR DESCRIPTION
The abs() function is a mathematical utility and does not belong in lib/memory.c, which is intended for memory manipulation routines. This commit moves abs() to a new lib/math.c file to improve semantic consistency and maintainability, and to provide a dedicated place for future math-related functions.

Fixes: #17