### PR TITLE
Revise comment of MIE.MEIE

### DIFF
--- a/arch/riscv/boot.c
+++ b/arch/riscv/boot.c
@@ -71,7 +71,7 @@ __attribute__((naked, section(".text.prologue"))) void _entry(void)
         "csrw   mtvec, t0\n"
 
         /* Enable machine-level external interrupts (MIE.MEIE).
-         * This allows peripherals like the CLINT timer to raise interrupts.
+         * This allows peripherals like the UART to raise interrupts.
          * Global interrupts remain disabled by mstatus.MIE until the scheduler
          * is ready.
          */


### PR DESCRIPTION
### Issue
The current comment incorrectly suggested that CLINT timer is controlled by MIE.MEIE.

Refer to RISC-V Privileged Spec, section 3.1 "Machine-Level CSRs  v1.13" (p.43), the CLINT timer interrupt is controlled by `MIE.MTIE` (bit 7), while `MIE.MEIE` (bit 11) is for external interrupts.

### Fix
Updated the comment to clarify that `MIE.MEIE` enables external interrupts (e.g., UART).