### PR TITLE
Fix false positive alarm in split_block() helper

### DIFF
--- a/lib/malloc.c
+++ b/lib/malloc.c
@@ -140,7 +140,7 @@ static inline void split_block(memblock_t *block, size_t size)
     size_t remaining;
     memblock_t *new_block;
 
-    if (unlikely(size >= GET_SIZE(block))) {
+    if (unlikely(size > GET_SIZE(block))) {
         panic(ERR_HEAP_CORRUPT);
         return;
     }


### PR DESCRIPTION
### Issue
commit 44eed33
The `split_block()` helper could incorrectly trigger a kernel panic when the requested allocation size was exactly equal to the current memory block size.

### Fix
Refer to PR #21

Adjusted the condition check in `split_block()` to properly handle equal-size requests, preventing false positive panic conditions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix false panic in split_block() when the requested size equals the block size. Change the check from >= to > so exact-size requests no longer trigger ERR_HEAP_CORRUPT.

<!-- End of auto-generated description by cubic. -->

