### PR TITLE
Replace constant stack canary with per-task random

### DIFF
--- a/include/sys/task.h
+++ b/include/sys/task.h
@@ -82,6 +82,9 @@ typedef struct tcb {
 
     /* Real-time Scheduling Support */
     void *rt_prio; /* Opaque pointer for custom real-time scheduler hook */
+
+    /* Stack Protection */
+    uint32_t canary; /* Random stack canary for overflow detection */
 } tcb_t;
 
 /* Kernel Control Block (KCB)

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -24,6 +24,13 @@ int32_t main(void)
     printf("Heap initialized, %u bytes available\n",
            (unsigned int) (size_t) &_heap_size);
 
+    /* Seed PRNG with hardware entropy for stack canary randomization.
+     * Combine cycle counter (mcycle) and us timer for unpredictability. This
+     * prevents fixed canary values across boots.
+     */
+    uint32_t entropy = read_csr(mcycle) ^ (uint32_t) _read_us();
+    srand(entropy);
+
     /* Initialize deferred logging system.
      * Must be done after heap init but before app_main() to ensure
      * application tasks can use thread-safe printf.


### PR DESCRIPTION
This commit replaces fixed STACK_CANARY (0x33333333U) with per-task random canary generated using xorshift32 PRNG. This prevents trivial canary forgery attacks and significantly improves stack overflow detection.

The xorshift32 PRNG provides sufficient entropy for embedded systems without MMU/MPU support. Future enhancements can improve PRNG seeding with hardware entropy sources.

Close #8





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the fixed stack canary with a per-task random canary to harden stack overflow detection and prevent trivial forgery. Each task gets its own canary from a lightweight xorshift32 PRNG seeded at boot with hardware entropy.

- **New Features**
  - Added tcb.canary; wrote it to both ends of each task’s stack.
  - Generated canary via random() with hardware-entropy seeding; fallback to 0xDEADBEEF if zero.
  - Updated stack check to validate against the task’s canary and print expected value.

<sup>Written for commit 4a8087c5838ea1b46233665cdba79f7b14c051bc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





