### PR TITLE
CI: Add commit hash link to test result comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,17 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
+          COMMIT_SHA="${{ github.sha }}"
+          COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "${{ github.sha }}" | cut -c1-7)
+          GITHUB_REPO="${{ github.repository }}"
+
           if [ "${{ matrix.toolchain }}" = "llvm" ]; then
             # LLVM: Build-only validation, skip tests
             mkdir -p test-results
             echo "${{ matrix.toolchain }}" > test-results/toolchain
+            echo "$COMMIT_SHA" > test-results/commit_sha
+            echo "$COMMIT_SHORT" > test-results/commit_short
+            echo "$GITHUB_REPO" > test-results/github_repo
             echo "skipped" > test-results/crash_exit_code
             echo "skipped" > test-results/functional_exit_code
 
@@ -163,7 +170,7 @@ jobs:
             echo "LLVM toolchain: Build validation only (tests skipped)"
           else
             # GNU: Full test suite
-            .ci/ci-tools.sh collect-data "${{ matrix.toolchain }}" "${{ steps.test.outputs.TEST_OUTPUT }}" "${{ steps.functional_test.outputs.FUNCTIONAL_TEST_OUTPUT }}"
+            .ci/ci-tools.sh collect-data "${{ matrix.toolchain }}" "$COMMIT_SHA" "$COMMIT_SHORT" "$GITHUB_REPO" "${{ steps.test.outputs.TEST_OUTPUT }}" "${{ steps.functional_test.outputs.FUNCTIONAL_TEST_OUTPUT }}"
           fi
 
       - name: Upload Test Results


### PR DESCRIPTION
This displays git commit hash (short) with clickable link to GitHub commit in pull request test result comments for easier traceability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clickable commit link in CI test result comments for quick traceability. The workflow records the commit SHA, short hash, and repo and includes them in the aggregated report.

- **New Features**
  - Store commit_sha, commit_short, and github_repo in test results and the TOML summary.
  - Build a GitHub commit URL in format_comment and show “Commit: [`short`](/commit/sha)” in PR comments.
  - Workflow sets COMMIT_SHA, COMMIT_SHORT, and GITHUB_REPO and passes them to collect-data; LLVM path writes them too.

- **Migration**
  - collect-data now requires: <toolchain> <commit_sha> <commit_short> <github_repo> <test_output> [functional_output]. Update any callers.

<sup>Written for commit 209c2416a4c369f80709a5f67711ae42af609158. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

