### PR TITLE
CI: Add CodeQL static code analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: "CodeQL"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  analyze:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential qemu-system-riscv32 wget
+
+      - name: Setup toolchain
+        run: .ci/setup-toolchain.sh gnu
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: cpp
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow for CodeQL to perform static analysis on the C codebase.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions CodeQL workflow to run static analysis on the C/C++ codebase for pushes and PRs to main. The job builds on ubuntu-24.04 (installs build deps and toolchain, runs make) and analyzes with github/codeql-action v4.

<sup>Written for commit 35088952af0f6232197f9b381ee53e9893fb96e6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



