### PR TITLE
Remove free() in mo_task_cancel()

### DIFF
--- a/kernel/task.c
+++ b/kernel/task.c
@@ -670,7 +670,6 @@ int32_t mo_task_cancel(uint16_t id)
     /* Free memory outside critical section */
     free(tcb->stack);
     free(tcb);
-    free(node);
     return ERR_OK;
 }
 


### PR DESCRIPTION
This PR removes redundant free() in mo_task_cancel(), which has been called in list_remove().

As mentioned in #49 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant free(node) in mo_task_cancel(); list_remove() already frees the node. This prevents double-free and potential crashes or heap corruption when canceling a task.

<sup>Written for commit 39c02129e190ee9981e5dd5dcb630a60505dbf75. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

