### PR TITLE
Implement EDF scheduler with ecall-based context switch

### DIFF
--- a/app/rtsched.c
+++ b/app/rtsched.c
@@ -1,144 +1,491 @@
 #include <linmo.h>
 
-/* Task 4: Simple task that prints a message and waits for scheduling */
-static void task4(void)
+/* Extended task statistics for fairness validation */
+typedef struct {
+    uint32_t executions;      /* Total number of job executions */
+    uint32_t deadline_misses; /* Count of missed deadlines (RT tasks only) */
+    uint32_t total_response;  /* Sum of response times (release to start) */
+    uint32_t max_response, min_response; /* Max/Min response time observed */
+    uint32_t period;                     /* Task period (0 for non-RT) */
+    uint32_t deadline;                   /* Relative deadline (0 for non-RT) */
+} task_stats_t;
+
+/* Global statistics - indexed by task number 0-4 */
+static task_stats_t task_stats[5];
+static volatile uint32_t test_start_time = 0;
+
+/* Flag to indicate test has started.
+ * Note: This has a benign race condition - multiple tasks may observe
+ * test_started=0 simultaneously and attempt to set test_start_time.
+ * This is acceptable because: (1) all tasks set similar values (current tick),
+ * and (2) EDF ensures the highest-priority task runs first anyway.
+ * A proper fix would use a mutex, but the overhead is unnecessary here.
+ */
+static volatile int test_started = 0;
+static uint32_t test_duration = 50; /* Run for 50 ticks for better statistics */
+
+/* Set to 1+ to enable workload simulation for response time testing */
+#define WORKLOAD_TICKS 0
+
+/* Simulate workload: busy-wait for WORKLOAD_TICKS timer periods.
+ * When WORKLOAD_TICKS=0 (default), this is a no-op.
+ */
+#if WORKLOAD_TICKS > 0
+static void simulate_workload(void)
 {
-    while (1) {
-        printf("Task 4 running\n");
-        mo_task_wfi(); /* Wait for interrupt to yield control */
+    uint32_t start = mo_ticks();
+    while (mo_ticks() - start < WORKLOAD_TICKS) {
+        /* Busy wait to consume CPU time */
+        for (volatile int i = 0; i < 1000; i++)
+            ;
     }
 }
+#else
+#define simulate_workload() ((void) 0)
+#endif
 
-/* Task 3: Simple task that prints a message and waits for scheduling */
-static void task3(void)
-{
-    while (1) {
-        printf("Task 3 running\n");
-        mo_task_wfi(); /* Wait for interrupt to yield control */
-    }
-}
-
-/* Task 2: Prints task ID and an incrementing counter, then waits */
-static void task2(void)
-{
-    int32_t cnt = 300000;
-
-    while (1) {
-        printf("[Task %d: %ld]\n", mo_task_id(), cnt++);
-        mo_task_wfi(); /* Yield control to scheduler */
-    }
-}
-
-/* Task 1: Prints task ID and an incrementing counter, then waits */
-static void task1(void)
-{
-    int32_t cnt = 200000;
-
-    while (1) {
-        printf("[Task %d: %ld]\n", mo_task_id(), cnt++);
-        mo_task_wfi(); /* Yield control to scheduler */
-    }
-}
-
-/* Task 0: Prints task ID and an incrementing counter, then waits */
+/* Task 0: RT task with period=10 */
 static void task0(void)
 {
-    int32_t cnt = 100000;
+    int idx = 0;
+    uint32_t period = 10;
+    uint32_t theoretical_release;
+    uint32_t job_start;
+    uint32_t response_time;
 
+    /* Initialize stats */
+    task_stats[idx].period = period;
+    task_stats[idx].deadline = period; /* implicit deadline = period */
+    task_stats[idx].min_response = UINT32_MAX;
+
+    /* Initialize test_start_time on first task execution */
+    if (!test_started) {
+        test_start_time = mo_ticks();
+        test_started = 1;
+    }
+
+    /* First job theoretical release time = test start */
+    theoretical_release = test_start_time;
+
+    while (mo_ticks() - test_start_time < test_duration) {
+        /* Record actual start time */
+        job_start = mo_ticks();
+
+        /* Response time = actual start - theoretical release */
+        response_time = job_start - theoretical_release;
+
+        /* Track response time statistics */
+        task_stats[idx].total_response += response_time;
+        if (response_time > task_stats[idx].max_response)
+            task_stats[idx].max_response = response_time;
+        if (response_time < task_stats[idx].min_response)
+            task_stats[idx].min_response = response_time;
+
+        /* Check deadline miss (response > deadline) */
+        if (response_time > task_stats[idx].deadline)
+            task_stats[idx].deadline_misses++;
+
+        task_stats[idx].executions++;
+
+        /* Simulate workload to test response time measurement */
+        simulate_workload();
+
+        /* Calculate next theoretical release time */
+        theoretical_release += period;
+
+        /* Delay until next period */
+        uint32_t now = mo_ticks();
+        if (now < theoretical_release)
+            mo_task_delay(theoretical_release - now);
+    }
+
+    /* Clear RT priority so EDF stops selecting this task */
+    mo_task_rt_priority(mo_task_id(), NULL);
+    while (1)
+        mo_task_wfi();
+}
+
+/* Task 1: RT task with period=15 */
+static void task1(void)
+{
+    int idx = 1;
+    uint32_t period = 15;
+    uint32_t theoretical_release;
+    uint32_t job_start;
+    uint32_t response_time;
+
+    /* Initialize stats */
+    task_stats[idx].period = period;
+    task_stats[idx].deadline = period;
+    task_stats[idx].min_response = UINT32_MAX;
+
+    /* Wait for test to start */
+    while (!test_started)
+        mo_task_delay(1);
+
+    /* First job theoretical release time = test start */
+    theoretical_release = test_start_time;
+
+    while (mo_ticks() - test_start_time < test_duration) {
+        job_start = mo_ticks();
+        response_time = job_start - theoretical_release;
+
+        task_stats[idx].total_response += response_time;
+        if (response_time > task_stats[idx].max_response)
+            task_stats[idx].max_response = response_time;
+        if (response_time < task_stats[idx].min_response)
+            task_stats[idx].min_response = response_time;
+        if (response_time > task_stats[idx].deadline)
+            task_stats[idx].deadline_misses++;
+
+        task_stats[idx].executions++;
+
+        /* Simulate workload */
+        simulate_workload();
+
+        theoretical_release += period;
+        uint32_t now = mo_ticks();
+        if (now < theoretical_release)
+            mo_task_delay(theoretical_release - now);
+    }
+
+    mo_task_rt_priority(mo_task_id(), NULL);
+    while (1)
+        mo_task_wfi();
+}
+
+/* Task 2: RT task with period=20 */
+static void task2(void)
+{
+    int idx = 2;
+    uint32_t period = 20;
+    uint32_t theoretical_release;
+    uint32_t job_start;
+    uint32_t response_time;
+
+    /* Initialize stats */
+    task_stats[idx].period = period;
+    task_stats[idx].deadline = period;
+    task_stats[idx].min_response = UINT32_MAX;
+
+    /* Wait for test to start */
+    while (!test_started)
+        mo_task_delay(1);
+
+    /* First job theoretical release time = test start */
+    theoretical_release = test_start_time;
+
+    while (mo_ticks() - test_start_time < test_duration) {
+        job_start = mo_ticks();
+        response_time = job_start - theoretical_release;
+
+        task_stats[idx].total_response += response_time;
+        if (response_time > task_stats[idx].max_response)
+            task_stats[idx].max_response = response_time;
+        if (response_time < task_stats[idx].min_response)
+            task_stats[idx].min_response = response_time;
+        if (response_time > task_stats[idx].deadline)
+            task_stats[idx].deadline_misses++;
+
+        task_stats[idx].executions++;
+
+        /* Simulate workload */
+        simulate_workload();
+
+        theoretical_release += period;
+        uint32_t now = mo_ticks();
+        if (now < theoretical_release)
+            mo_task_delay(theoretical_release - now);
+    }
+
+    mo_task_rt_priority(mo_task_id(), NULL);
+    while (1)
+        mo_task_wfi();
+}
+
+/* Task 3: Non-RT background task */
+static void task3(void)
+{
+    int idx = 3;
+    uint32_t period = 25;
+
+    task_stats[idx].period = period;
+
+    while (!test_started)
+        mo_task_delay(1);
+
+    while (mo_ticks() - test_start_time < test_duration) {
+        task_stats[idx].executions++;
+        mo_task_delay(period);
+    }
+    while (1)
+        mo_task_wfi();
+}
+
+/* Print scheduling statistics using stdio with flush for ordered output */
+static void print_stats(void)
+{
+    /* Flush pending logger output to ensure report appears in order */
+    mo_logger_flush();
+
+    printf("\n========================================\n");
+    printf("    EDF Scheduler Statistics Report    \n");
+    printf("========================================\n");
+    printf("Test duration: %lu ticks\n\n", (unsigned long) test_duration);
+
+    printf("--- RT Task Statistics ---\n");
+    for (int i = 0; i < 3; i++) {
+        /* Ceiling division: task at t=0 runs once even for partial periods */
+        uint32_t expected =
+            (test_duration + task_stats[i].period - 1) / task_stats[i].period;
+        printf("Task %d (period=%lu, deadline=%lu):\n", i,
+               (unsigned long) task_stats[i].period,
+               (unsigned long) task_stats[i].deadline);
+        printf("  Executions: %lu (expected: %lu)\n",
+               (unsigned long) task_stats[i].executions,
+               (unsigned long) expected);
+        printf("  Deadline misses: %lu\n",
+               (unsigned long) task_stats[i].deadline_misses);
+
+        if (task_stats[i].executions > 0) {
+            uint32_t avg_response =
+                task_stats[i].total_response / task_stats[i].executions;
+            uint32_t jitter =
+                task_stats[i].max_response - task_stats[i].min_response;
+            printf("  Response time - min: %lu, max: %lu, avg: %lu\n",
+                   (unsigned long) task_stats[i].min_response,
+                   (unsigned long) task_stats[i].max_response,
+                   (unsigned long) avg_response);
+            printf("  Jitter (max-min): %lu ticks\n", (unsigned long) jitter);
+        }
+        printf("\n");
+    }
+
+    printf("--- Non-RT Task Statistics ---\n");
+    for (int i = 3; i < 5; i++) {
+        printf("Task %d (period=%lu):\n", i,
+               (unsigned long) task_stats[i].period);
+        printf("  Executions: %lu\n\n",
+               (unsigned long) task_stats[i].executions);
+    }
+
+    printf("--- Fairness Analysis ---\n");
+
+    /* 1. Deadline miss check */
+    uint32_t total_deadline_misses = 0;
+    for (int i = 0; i < 3; i++)
+        total_deadline_misses += task_stats[i].deadline_misses;
+    printf("1. Deadline misses: %lu %s\n",
+           (unsigned long) total_deadline_misses,
+           total_deadline_misses == 0 ? "[PASS]" : "[FAIL]");
+
+    /* 2. Execution count fairness */
+    int exec_ok = 1;
+    for (int i = 0; i < 3; i++) {
+        /* Ceiling division: task at t=0 runs once even for partial periods */
+        uint32_t expected =
+            (test_duration + task_stats[i].period - 1) / task_stats[i].period;
+        uint32_t actual = task_stats[i].executions;
+        /* Avoid underflow: check actual+1 < expected */
+        if (actual + 1 < expected || actual > expected + 1)
+            exec_ok = 0;
+    }
+    printf("2. Execution count: %s\n", exec_ok ? "[PASS] within expected range"
+                                               : "[FAIL] unexpected count");
+
+    /* 3. Response time bounded by deadline */
+    int response_ok = 1;
+    for (int i = 0; i < 3; i++) {
+        if (task_stats[i].max_response > task_stats[i].deadline)
+            response_ok = 0;
+    }
+    printf("3. Response bounded: %s\n",
+           response_ok ? "[PASS] max_response <= deadline"
+                       : "[FAIL] response exceeded deadline");
+
+    /* 4. Jitter analysis */
+    int jitter_ok = 1;
+    for (int i = 0; i < 3; i++) {
+        if (task_stats[i].executions > 0) {
+            uint32_t jitter =
+                task_stats[i].max_response - task_stats[i].min_response;
+            if (jitter > task_stats[i].period / 2)
+                jitter_ok = 0;
+        }
+    }
+    printf("4. Jitter acceptable: %s\n", jitter_ok
+                                             ? "[PASS] jitter < 50% period"
+                                             : "[WARN] high jitter detected");
+
+    /* 5. Non-RT task starvation check */
+    int starvation_ok =
+        (task_stats[3].executions > 0 || task_stats[4].executions > 0);
+    printf("5. Non-RT starvation: %s\n", starvation_ok
+                                             ? "[PASS] non-RT tasks executed"
+                                             : "[FAIL] non-RT tasks starved");
+
+    /* Overall verdict */
+    printf("\n--- Overall Verdict ---\n");
+    printf("EDF Scheduler: %s\n", (total_deadline_misses == 0 && exec_ok &&
+                                   response_ok && starvation_ok)
+                                      ? "All tests passed"
+                                      : "Some tests failed");
+    printf("========================================\n");
+
+    /* Re-enable async logging for any subsequent output */
+    mo_logger_async_resume();
+}
+
+/* Task 4: Statistics collector and reporter */
+static void task4(void)
+{
+    int idx = 4;
+
+    task_stats[idx].period = 1; /* Runs every tick */
+
+    /* Wait for test to start */
+    while (!test_started)
+        mo_task_delay(1);
+
+    /* Monitor test progress */
+    while (mo_ticks() - test_start_time < test_duration) {
+        task_stats[idx].executions++;
+        mo_task_delay(1);
+    }
+
+    /* Wait a bit for other tasks to complete */
+    mo_task_delay(5);
+
+    /* Print comprehensive statistics */
+    print_stats();
+
+    while (1)
+        mo_task_wfi();
+}
+
+/* IDLE task: Always ready, runs when all other tasks blocked */
+static void idle_task(void)
+{
     while (1) {
-        printf("[Task %d: %ld]\n", mo_task_id(), cnt++);
-        mo_task_wfi(); /* Yield control to scheduler */
+        /* Just burn CPU cycles - don't yield or delay */
+        for (volatile int i = 0; i < 100; i++)
+            ;
     }
 }
 
 typedef struct {
-    unsigned credits;
-    unsigned remaining;
-} custom_prio_t;
+    uint32_t period;   /* Task period in ticks */
+    uint32_t deadline; /* Absolute deadline (ticks) */
+} edf_prio_t;
 
-/* A simple credit-based real-time scheduler
- * – Every RT task carries a custom_prio_t record via its tcb_t::rt_prio field.
- * – Each time the scheduler selects a task it decrements "remaining".
- *   When "remaining" reaches zero it is reloaded from "credits" on the task’s
- *   next turn.
- * – The function returns the ID of the selected RT task, or –1 when no RT task
- *   is ready so the kernel should fall back to its round-robin scheduler.
+/* Earliest Deadline First (EDF) real-time scheduler
+ * – Every RT task carries an edf_prio_t record via its tcb_t::rt_prio field.
+ * – The scheduler selects the READY RT task with the earliest absolute
+ * deadline. – When a task is selected, its deadline advances to the next
+ * period. – Returns the ID of the selected RT task, or -1 when no RT task is
+ * ready.
+ *
+ * Deadline Update Strategy:
+ * – Deadline advances (deadline += period) when a task is selected from READY.
+ * – For periodic tasks that delay for their period (mo_task_delay(period)),
+ *   this approximates correct EDF semantics: tasks become READY at period
+ *   boundaries, get selected shortly after, and deadline advances correctly.
+ * – This approach is simpler than tracking job releases separately.
+ * – Tasks must delay for their period to ensure correct periodic behavior.
+ *
+ * EDF is optimal for single-core systems: if any scheduler can meet all
+ * deadlines, EDF can. Complexity: O(n) where n = number of RT tasks.
  */
-static int32_t custom_sched(void)
+static int32_t edf_sched(void)
 {
-    static list_node_t *task_node = NULL; /* resume point */
+    tcb_t *earliest = NULL;
+    uint32_t earliest_deadline = UINT32_MAX;
 
-    /* If we have no starting point or we’ve wrapped, begin at head->next */
-    if (!task_node)
-        task_node = list_next(kcb->tasks->head);
-
-    /* Scan at most one full loop of the list */
-    list_node_t *start = task_node;
-    do {
-        if (!task_node) /* empty list */
-            return -1;
-
-        /* Skip head/tail sentinels and NULL-data nodes */
-        if (task_node == kcb->tasks->head || task_node == kcb->tasks->tail ||
-            !task_node->data) {
-            task_node = list_next(task_node);
+    /* Scan all tasks to find the one with earliest deadline */
+    list_node_t *node = list_next(kcb->tasks->head);
+    while (node && node != kcb->tasks->tail) {
+        if (!node->data) {
+            node = list_next(node);
             continue;
         }
 
-        /* Safe: data is non-NULL here */
-        tcb_t *task = (tcb_t *) task_node->data;
+        tcb_t *task = (tcb_t *) node->data;
 
-        /* READY + RT-eligible ? */
-        if (task->state == TASK_READY && task->rt_prio) {
-            /* Consume one credit */
-            custom_prio_t *cp = (custom_prio_t *) task->rt_prio;
-            if (cp->remaining == 0)
-                cp->remaining = cp->credits;
-            cp->remaining--;
+        /* Consider both READY and RUNNING RT tasks for preemptive scheduling */
+        if ((task->state == TASK_READY || task->state == TASK_RUNNING) &&
+            task->rt_prio) {
+            edf_prio_t *edf = (edf_prio_t *) task->rt_prio;
 
-            /* Next time resume with the following node */
-            task_node = list_next(task_node);
-            if (task_node == kcb->tasks->head || task_node == kcb->tasks->tail)
-                task_node = list_next(task_node); /* skip sentinel  */
-            return task->id;
+            /* Track task with earliest deadline */
+            if (edf->deadline < earliest_deadline) {
+                earliest_deadline = edf->deadline;
+                earliest = task;
+            }
         }
 
-        /* Otherwise advance */
-        task_node = list_next(task_node);
-    } while (task_node != start); /* one full lap */
+        node = list_next(node);
+    }
 
-    /* No READY RT task this cycle */
-    task_node = NULL; /* restart next */
-    return -1;
+    /* DON'T advance deadline here - that would happen on EVERY scheduler call!
+     * Deadline should only advance when task actually releases next job.
+     * For now, just return the selected task. Deadline advancement will happen
+     * when task becomes READY again after delay expires.
+     */
+
+    /* Return selected task ID, or -1 if no RT task is ready */
+    return earliest ? earliest->id : -1;
 }
 
 /* Application Entry Point: Initializes tasks and scheduler
  *
- * Spawns five tasks, assigns real-time priorities to tasks 0, 1, and 2,
- * and sets up the custom credit-based scheduler. Enables preemptive mode.
+ * RT Task Configuration (EDF scheduling):
+ * - Task 0: period = 10 ticks, utilization = 10%
+ * - Task 1: period = 15 ticks, utilization = 6.7%
+ * - Task 2: period = 20 ticks, utilization = 5%
+ * - Task 3: Non-RT background task (period = 25 ticks)
+ * - Task 4: Non-RT background task (period = 25 ticks)
+ *
+ * Total RT Utilization: ~21.7% (well under EDF's 100% bound)
  */
 int32_t app_main(void)
 {
-    /* Define RT task priorities with initial credit values */
-    static custom_prio_t priorities[3] = {
-        {.credits = 3, .remaining = 3}, /* Task 0 */
-        {.credits = 4, .remaining = 4}, /* Task 1 */
-        {.credits = 5, .remaining = 5}, /* Task 2 */
-    };
+    /* test_start_time will be initialized by first task that runs */
 
-    /* Spawn tasks with default stack size */
-    mo_task_spawn(task0, DEFAULT_STACK_SIZE);
-    mo_task_spawn(task1, DEFAULT_STACK_SIZE);
-    mo_task_spawn(task2, DEFAULT_STACK_SIZE);
-    mo_task_spawn(task3, DEFAULT_STACK_SIZE);
-    mo_task_spawn(task4, DEFAULT_STACK_SIZE);
+    /* Spawn all 5 RT/background tasks first */
+    int32_t tid0 = mo_task_spawn(task0, DEFAULT_STACK_SIZE);
+    int32_t tid1 = mo_task_spawn(task1, DEFAULT_STACK_SIZE);
+    int32_t tid2 = mo_task_spawn(task2, DEFAULT_STACK_SIZE);
+    (void) mo_task_spawn(task3, DEFAULT_STACK_SIZE); /* Non-RT task 3 */
+    /* Non-RT task 4 - displays stats */
+    (void) mo_task_spawn(task4, DEFAULT_STACK_SIZE);
 
-    /* Configure custom scheduler and assign RT priorities */
-    kcb->rt_sched = custom_sched;
-    mo_task_rt_priority(0, &priorities[0]);
-    mo_task_rt_priority(1, &priorities[1]);
-    mo_task_rt_priority(2, &priorities[2]);
+    /* Spawn IDLE task LAST so it's at end of round-robin list.
+     * This ensures other ready tasks get scheduled before IDLE.
+     */
+    (void) mo_task_spawn(idle_task, DEFAULT_STACK_SIZE);
 
-    /* preemptive scheduling */
+    /* Configure EDF priorities for RT tasks 0-2 with deadlines relative to
+     * current time */
+    uint32_t now = mo_ticks();
+    static edf_prio_t priorities[3];
+    priorities[0].period = 10;
+    priorities[0].deadline = now + 10;
+    priorities[1].period = 15;
+    priorities[1].deadline = now + 15;
+    priorities[2].period = 20;
+    priorities[2].deadline = now + 20;
+
+    /* Install EDF scheduler BEFORE setting priorities */
+    kcb->rt_sched = edf_sched;
+
+    mo_task_rt_priority(tid0, &priorities[0]);
+    mo_task_rt_priority(tid1, &priorities[1]);
+    mo_task_rt_priority(tid2, &priorities[2]);
+
+    /* Tasks 3-4 are non-RT, will use round-robin when no RT tasks ready */
+
+    printf("[RTSCHED] Current tick: %lu\n", (unsigned long) mo_ticks());
+
+    /* Return 1 for preemptive mode */
     return 1;
 }

--- a/arch/riscv/boot.c
+++ b/arch/riscv/boot.c
@@ -156,11 +156,18 @@ __attribute__((naked, aligned(4))) void _isr(void)
         /* Save trap-related CSRs and prepare arguments for do_trap */
         "csrr   a0, mcause\n" /* Arg 1: cause */
         "csrr   a1, mepc\n"   /* Arg 2: epc */
+        "mv     a2, sp\n"     /* Arg 3: isr_sp (current stack frame) */
         "sw     a0,  30*4(sp)\n"
         "sw     a1,  31*4(sp)\n"
 
-        /* Call the high-level C trap handler */
+        /* Call the high-level C trap handler.
+         * Returns: a0 = SP to use for restoring context (may be different
+         * task's stack if context switch occurred).
+         */
         "call   do_trap\n"
+
+        /* Use returned SP for context restore (enables context switching) */
+        "mv     sp, a0\n"
 
         /* Restore context. mepc might have been modified by the handler */
         "lw     a1,  31*4(sp)\n"

--- a/arch/riscv/hal.h
+++ b/arch/riscv/hal.h
@@ -76,6 +76,12 @@ int32_t hal_context_save(jmp_buf env);
 void hal_context_restore(jmp_buf env, int32_t val);
 void hal_dispatch_init(jmp_buf env);
 
+/* Stack switching for preemptive context switch.
+ * Saves current SP to *old_sp and loads new SP from new_sp.
+ * Used by dispatcher when switching tasks in preemptive mode.
+ */
+void hal_switch_stack(void **old_sp, void *new_sp);
+
 /* Provides a blocking, busy-wait delay.
  * This function monopolizes the CPU and should only be used for very short
  * delays or in pre-scheduling initialization code.
@@ -92,7 +98,14 @@ uint64_t _read_us(void);
 void hal_hardware_init(void);
 void hal_timer_enable(void);
 void hal_timer_disable(void);
-void hal_interrupt_tick(void);
+void hal_timer_irq_enable(
+    void); /* Enable timer interrupt bit only (for NOSCHED) */
+void hal_timer_irq_disable(
+    void); /* Disable timer interrupt bit only (for NOSCHED) */
+void hal_interrupt_tick(void); /* Enable interrupts on first task run */
+void *hal_build_initial_frame(
+    void *stack_top,
+    void (*task_entry)(void)); /* Build ISR frame for preemptive mode */
 
 /* Initializes the context structure for a new task.
  * @ctx : Pointer to jmp_buf to initialize (must be non-NULL).
@@ -109,4 +122,4 @@ void hal_panic(void);
 void hal_cpu_idle(void);
 
 /* Default stack size for new tasks if not otherwise specified */
-#define DEFAULT_STACK_SIZE 4096
+#define DEFAULT_STACK_SIZE 8192

--- a/include/sys/logger.h
+++ b/include/sys/logger.h
@@ -58,3 +58,21 @@ uint32_t mo_logger_queue_depth(void);
  * Returns total dropped message count since logger init
  */
 uint32_t mo_logger_dropped_count(void);
+
+/* Check if logger is in direct output mode.
+ * Lock-free read for performance - safe to call frequently.
+ * Returns true if printf/puts should bypass the queue.
+ */
+bool mo_logger_direct_mode(void);
+
+/* Flush all pending messages and enter direct output mode.
+ * Drains the queue directly from caller's context.
+ * After flush, printf/puts bypass the queue for ordered output.
+ * Call mo_logger_async_resume() to re-enable async logging.
+ */
+void mo_logger_flush(void);
+
+/* Re-enable async logging after a flush.
+ * Call this after completing ordered output that required direct mode.
+ */
+void mo_logger_async_resume(void);

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -67,6 +67,11 @@ int32_t main(void)
     if (!first_task)
         panic(ERR_NO_TASKS);
 
+    /* Mark scheduler as started - enables timer IRQ in NOSCHED_LEAVE.
+     * Must be set before hal_dispatch_init() which enables preemption.
+     */
+    scheduler_started = true;
+
     hal_dispatch_init(first_task->context);
 
     /* This line should be unreachable. */


### PR DESCRIPTION
The preemptive EDF (Earliest Deadline First) scheduler requires a mechanism for tasks to voluntarily yield CPU time while blocked on delays. In RISC-V M-mode, the ecall instruction provides a clean way to trigger a synchronous trap that invokes the scheduler without relying on timer interrupts.

The dispatcher function now accepts a from_timer parameter to distinguish between timer-driven preemption and ecall-driven yields. Timer interrupts increment the system tick counter and process time slices, while ecall-based yields skip tick advancement to prevent time drift.

When handling ecall from M-mode, the trap handler advances mepc past the 4-byte ecall instruction to prevent re-execution upon return. Critically, the ISR stack frame must also be updated because the ISR epilogue restores mepc from the saved frame rather than the CSR directly. Without this fix, mret would jump back to the ecall instruction causing an infinite trap loop.

The logger subsystem gains a flush mechanism with a direct_mode flag that bypasses the async queue. This ensures multi-line output like statistics reports prints in order, as printf normally enqueues to the ring buffer which the logger task drains asynchronously.

The rtsched test application validates the EDF implementation by running periodic RT tasks with different periods and deadlines, measuring execution counts, deadline misses, response times, and jitter to verify correct scheduler behavior.

Close #26











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a preemptive EDF scheduler with ecall-based context switching on RISC‑V and a flushable logger for ordered output. Includes a test app that validates deadlines, response times, jitter, fairness, and non‑RT starvation.

- **New Features**
  - EDF RT scheduler: picks earliest absolute deadline; deadlines reset on period expiry; non‑RT uses round‑robin.
  - RISC‑V ecall yield: trap advances mepc and ISR frame, passes/returns SP to do_trap, and calls dispatcher(0); timer ISR calls dispatcher(1) and maintains mtimecmp.
  - Preemptive plumbing: dispatcher(int from_timer); TCB.sp; hal_build_initial_frame(), hal_switch_stack(); hal_timer_irq_enable()/disable(); NOSCHED toggles MTIE and is gated by scheduler_started; direct UART in traps; default task stack is 8 KiB.
  - Logger: mo_logger_flush(), mo_logger_async_resume(), mo_logger_direct_mode(); printf/puts honor direct mode to keep multi‑line reports ordered.
  - rtsched app: 3 periodic RT tasks + background + idle; aggregates executions/misses/response/jitter and prints fairness/starvation summary.

- **Migration**
  - Update dispatcher() calls to dispatcher(int from_timer) (timer: 1; ecall/yield: 0).
  - Wrap multi‑line reports with mo_logger_flush() … mo_logger_async_resume() for ordered output.
  - For non‑RISC‑V ports, implement hal_switch_stack(), hal_build_initial_frame(), and hal_timer_irq_enable()/disable().
  - Note: NOSCHED macros no longer retarget mtimecmp; they only toggle the timer interrupt bit and respect scheduler_started. Default task stack is now 8 KiB.

<sup>Written for commit 424616f81330789fa9c3642aed2222ddeef98484. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













