### PR TITLE
Fix task ID inconsistency in 'app/suspend'

### DIFF
--- a/app/suspend.c
+++ b/app/suspend.c
@@ -1,5 +1,7 @@
 #include <linmo.h>
 
+int32_t task0_id, task1_id, task2_id;
+
 void task2(void)
 {
     int32_t cnt = 0;
@@ -16,14 +18,14 @@ void task1(void)
     while (1) {
         printf("[task %d %ld]\n", mo_task_id(), cnt++);
         if (cnt == 2000) {
-            val = mo_task_resume(2);
+            val = mo_task_resume(task2_id);
             if (val == 0)
                 printf("TASK 2 RESUMED!\n");
             else
                 printf("FAILED TO RESUME TASK 2\n");
         }
         if (cnt == 6000) {
-            val = mo_task_resume(0);
+            val = mo_task_resume(task0_id);
             if (val == 0)
                 printf("TASK 0 RESUMED!\n");
             else
@@ -39,7 +41,7 @@ void task0(void)
     while (1) {
         printf("[task %d %ld]\n", mo_task_id(), cnt++);
         if (cnt == 1000) {
-            val = mo_task_suspend(2);
+            val = mo_task_suspend(task2_id);
             if (val == 0)
                 printf("TASK 2 SUSPENDED!\n");
             else
@@ -54,9 +56,9 @@ void task0(void)
 
 int32_t app_main(void)
 {
-    mo_task_spawn(task0, DEFAULT_STACK_SIZE);
-    mo_task_spawn(task1, DEFAULT_STACK_SIZE);
-    mo_task_spawn(task2, DEFAULT_STACK_SIZE);
+    task0_id = mo_task_spawn(task0, DEFAULT_STACK_SIZE);
+    task1_id = mo_task_spawn(task1, DEFAULT_STACK_SIZE);
+    task2_id = mo_task_spawn(task2, DEFAULT_STACK_SIZE);
 
     /* preemptive mode */
     return 1;


### PR DESCRIPTION
The introduction of the logger task in previous commits changed the task creation order, which caused inconsistencies in fixed task ID assignments.

This commit binds the task ID directly from the creation parameter, ensuring deterministic and correct ID assignment regardless of task creation order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task ID mismatches in suspend.c by using the IDs returned from mo_task_spawn instead of hardcoded indices. This makes suspend/resume deterministic even if task creation order changes (e.g., after adding the logger task).

- **Bug Fixes**
  - Store task IDs (task0_id, task1_id, task2_id) from mo_task_spawn.
  - Use stored IDs in mo_task_resume/mo_task_suspend to target the correct task.

<sup>Written for commit c514fde867864210e8e451638b7249cefa3ea5fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

