### PR TITLE
Refine current-task check in mo_task_suspend()

### DIFF
--- a/kernel/task.c
+++ b/kernel/task.c
@@ -883,7 +883,7 @@ int32_t mo_task_suspend(uint16_t id)
     }
 
     task->state = TASK_SUSPENDED;
-    bool is_current = (kcb->task_current == node);
+    bool is_current = (kcb->task_current->data == task);
 
     CRITICAL_LEAVE();
 


### PR DESCRIPTION
The previous implementation compared `kcb->task_current` with the task’s list node in the global task list. A list node is only a linkage element, not a stable identifier for a task, so this comparison is not appropriate.

This patch updates the check to compare the task's data structure (TCB), which properly represents the task identity.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compare the task’s TCB instead of its list node in mo_task_suspend() when checking if the target is the running task. This clarifies intent and avoids using list linkage as identity; behavior is unchanged.

<sup>Written for commit bf76c9308f5f170d3b3795b5fefd858487d7a441. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



