### PR TITLE
Fix double freed in remove_self_from_waiters()

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -56,7 +56,6 @@ static bool remove_self_from_waiters(list_t *waiters)
     while (curr && curr != waiters->tail) {
         if (curr->data == self) {
             list_remove(waiters, curr);
-            free(curr);
             return true;
         }
         curr = curr->next;


### PR DESCRIPTION
Fix double freed in remove_self_from_waiters()

free() is already invoked in list_remove(). Freeing the same pointer twice can crash the program with an invalid free error or corrupt the heap.

Ensure a single memory-release path by removing the outer free() call.

close [#57](https://github.com/vicLin8712/linmo/issues/57)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant free in remove_self_from_waiters() to prevent a double-free when removing a waiter. list_remove() already frees the node, avoiding crashes and memory corruption in the mutex waiters list.

<sup>Written for commit 4948444bf19d85394bda2db3c5ea4749e8996e64. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



