### PR TITLE
Fix cumulative drift in periodic timers

### DIFF
--- a/include/sys/timer.h
+++ b/include/sys/timer.h
@@ -26,7 +26,10 @@ typedef enum {
 typedef struct {
     /* Timing Parameters */
     uint32_t deadline_ticks; /* Expiration time in absolute system ticks */
-    uint32_t period_ms;      /* Reload period in milliseconds */
+    uint32_t last_expected_fire_tick; /* Last calculated expected fire time for
+                                       * periodic timer
+                                       */
+    uint32_t period_ms;               /* Reload period in milliseconds */
 
     /* Timer Identification and State */
     uint16_t id;       /* Unique handle assigned by the kernel */


### PR DESCRIPTION
Currently, periodic timers allow errors to accumulate because the next deadline is calculated relative to the current system tick (now + period). Any latency in the tick handler execution—whether due to interrupt jitter or system load—permanently shifts the phase of all future expirations.

Fix the drift by anchoring the timer schedule to an absolute baseline. A new field, last_expected_fire_tick, is introduced to track the theoretical expiration time.

When the timer fires, the next deadline is now computed by advancing this expected time by the period, rather than relying on the actual execution time. This ensures the timer maintains its long-term frequency accuracy regardless of short-term scheduling delays.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent cumulative drift in periodic timers by scheduling against an expected baseline tick instead of now + period. Timers keep stable frequency even under interrupt jitter or handler delays.

- **Bug Fixes**
  - Added last_expected_fire_tick to track the theoretical next fire time.
  - On start, initialize last_expected_fire_tick and set deadline_ticks to this value.
  - On each auto-reload, advance last_expected_fire_tick by the period and set deadline_ticks from it.

<sup>Written for commit fff70361217554119307257aa9c23a774b37d2dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



