### PR TITLE
Add U-mode task isolation and fix self-termination

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -266,8 +266,10 @@ int sys_task_spawn(void *task, int stack_size)
 
 static int _tcancel(int id)
 {
-    if (unlikely(id <= 0))
+    if (unlikely(id <= 0 || id > (int) UINT16_MAX))
         return -EINVAL;
+    if ((uint16_t) id != mo_task_id())
+        return -EPERM;
 
     return mo_task_cancel(id);
 }
@@ -304,8 +306,10 @@ int sys_tdelay(int ticks)
 
 static int _tsuspend(int id)
 {
-    if (unlikely(id <= 0))
+    if (unlikely(id <= 0 || id > (int) UINT16_MAX))
         return -EINVAL;
+    if ((uint16_t) id != mo_task_id())
+        return -EPERM;
 
     return mo_task_suspend(id);
 }
@@ -317,10 +321,9 @@ int sys_tsuspend(int id)
 
 static int _tresume(int id)
 {
-    if (unlikely(id <= 0))
-        return -EINVAL;
-
-    return mo_task_resume(id);
+    (void) id;
+    /* U-mode cannot resume any task; suspended task cannot call syscall */
+    return -EPERM;
 }
 
 int sys_tresume(int id)
@@ -330,8 +333,10 @@ int sys_tresume(int id)
 
 static int _tpriority(int id, int priority)
 {
-    if (unlikely(id <= 0))
+    if (unlikely(id <= 0 || id > (int) UINT16_MAX))
         return -EINVAL;
+    if ((uint16_t) id != mo_task_id())
+        return -EPERM;
 
     return mo_task_priority(id, priority);
 }


### PR DESCRIPTION
U-mode tasks could previously control other tasks and had no way to properly terminate themselves. This adds permission checks to restrict task control syscalls to self-only operations and enables safe self-termination through the existing zombie task mechanism.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down U‑mode task control to self-only and adds safe self-termination via the zombie task path. This prevents user tasks from affecting others and ensures proper cleanup.

- **Bug Fixes**
  - U‑mode isolation and ID checks: tcancel/tsuspend/tpriority require id in 1..UINT16_MAX and equal to mo_task_id(); out-of-range ids return -EINVAL; others return -EPERM. tresume always returns -EPERM in U‑mode.
  - Safe self-termination: mo_task_cancel(self) sets TASK_ZOMBIE and yields; the scheduler reclaims it later. Zombie cleanup skips the current task; id == 0 still returns ERR_TASK_CANT_REMOVE.

<sup>Written for commit 8d968ab4939f70a712cbc009a9135e04ca716d32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

