### PR TITLE
Fix POSIX syscall handling for consistency

### DIFF
--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -116,24 +116,12 @@ static int _getpid(void)
     return 1;
 }
 
+/* linmo uses fixed heap via mo_heap_init, sbrk is not applicable */
 static int _sbrk(int incr)
 {
-    extern uint32_t _end, _stack;
-    static char *brk = (char *) &_end;
-    char *prev = brk;
-
-    if (unlikely(incr < 0)) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    if (unlikely(brk + incr >= (char *) &_stack)) {
-        errno = ENOMEM;
-        return -1;
-    }
-
-    brk += incr;
-    return (int) prev;
+    (void) incr;
+    errno = ENOMEM;
+    return -1;
 }
 
 static int _usleep(int usec)
@@ -180,7 +168,7 @@ static int _read(int file, char *ptr, int len)
         return -1;
     }
 
-    if (unlikely(file < 0)) {
+    if (unlikely(file < 0 || file > 2)) {
         errno = EBADF;
         return -1;
     }
@@ -199,7 +187,7 @@ static int _write(int file, char *ptr, int len)
         return -1;
     }
 
-    if (unlikely(file < 0)) {
+    if (unlikely(file < 0 || file > 2)) {
         errno = EBADF;
         return -1;
     }


### PR DESCRIPTION
The heap allocation syscall had an implementation incompatible with the kernel's fixed-size heap design, changed to a proper stub to match other unsupported POSIX syscalls. Also added file descriptor validation in I/O syscalls to reject unsupported values beyond standard streams.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align POSIX syscall behavior with the fixed-heap kernel by stubbing sbrk and tightening I/O file descriptor validation. This prevents unsupported memory growth and rejects non-standard FDs in read/write.

- **Bug Fixes**
  - Replace _sbrk with a stub that returns -1 and sets ENOMEM to match unsupported syscall handling.
  - Validate _read/_write file descriptors to only allow 0–2; invalid values return EBADF.

<sup>Written for commit 7baf078eafbaf68194b79ab96ca6754496b43258. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

